### PR TITLE
Address code review regarding style and gc

### DIFF
--- a/docs/x509.rst
+++ b/docs/x509.rst
@@ -491,17 +491,13 @@ X.509 CSR (Certificate Signing Request) Builder Object
         ...     x509.NameAttribute(x509.OID_COMMON_NAME, 'cryptography.io'),
         ... ]))
         >>> buidlder = builder.add_extension(
-        ...     x509.BasicConstraints(False, None), critical=True,
+        ...     x509.BasicConstraints(ca=False, path_length=None), critical=True,
         ... )
         >>> request = builder.sign(
-        ...     default_backend(), private_key, hashes.SHA1()
+        ...     default_backend(), private_key, hashes.SHA256()
         ... )
         >>> isinstance(request, x509.CertificateSigningRequest)
         True
-
-    .. method:: __init__()
-
-        Creates an empty certificate signing request.
 
     .. method:: subject_name(name)
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -76,13 +76,13 @@ def _encode_asn1_int(backend, x):
     return i
 
 
-def _encode_asn1_str(backend, x, n):
+def _encode_asn1_str(backend, data, length):
     """
     Create an ASN1_OCTET_STRING from a Python byte string.
     """
     s = backend._lib.ASN1_OCTET_STRING_new()
     s = backend._ffi.gc(s, backend._lib.ASN1_OCTET_STRING_free)
-    backend._lib.ASN1_OCTET_STRING_set(s, x, n)
+    backend._lib.ASN1_OCTET_STRING_set(s, data, length)
     return s
 
 
@@ -118,17 +118,18 @@ def _txt2obj(backend, name):
     return obj
 
 
-def _encode_basic_constraints(backend, ca=False, pathlen=0, critical=False):
+def _encode_basic_constraints(backend, basic_constraints, critical):
     obj = _txt2obj(backend, x509.OID_BASIC_CONSTRAINTS.dotted_string)
     assert obj is not None
     constraints = backend._lib.BASIC_CONSTRAINTS_new()
-    constraints.ca = 255 if ca else 0
-    if ca:
-        constraints.pathlen = _encode_asn1_int(backend, pathlen)
+    constraints.ca = 255 if basic_constraints.ca else 0
+    if basic_constraints.ca:
+        constraints.pathlen = _encode_asn1_int(
+            backend, basic_constraints.path_length
+        )
 
     # Fetch the encoded payload.
-    pp = backend._ffi.new('unsigned char**')
-    assert pp != backend._ffi.NULL
+    pp = backend._ffi.new('unsigned char **')
     r = backend._lib.i2d_BASIC_CONSTRAINTS(constraints, pp)
     assert r > 0
 
@@ -141,8 +142,8 @@ def _encode_basic_constraints(backend, ca=False, pathlen=0, critical=False):
     )
     assert extension != backend._ffi.NULL
 
+    pp[0] = backend._ffi.gc(pp[0], backend._lib.OPENSSL_free)
     # Release acquired memory.
-    backend._lib.OPENSSL_free(pp[0])
     pp[0] = backend._ffi.NULL
 
     # Return the wrapped extension.
@@ -792,6 +793,7 @@ class Backend(object):
 
         # Create an empty request.
         x509_req = self._lib.X509_REQ_new()
+        x509_req = self._ffi.gc(x509_req, self._lib.X509_REQ_free)
         assert x509_req != self._ffi.NULL
 
         # Set x509 version.
@@ -821,12 +823,11 @@ class Backend(object):
             if isinstance(extension.value, x509.BasicConstraints):
                 extension = _encode_basic_constraints(
                     self,
-                    extension.value.ca,
-                    extension.value.path_length,
+                    extension.value,
                     extension.critical
                 )
             else:
-                raise ValueError('Extension not yet supported.')
+                raise NotImplementedError('Extension not yet supported.')
             res = self._lib.sk_X509_EXTENSION_push(extensions, extension)
             assert res == 1
         res = self._lib.X509_REQ_add_extensions(x509_req, extensions)

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -551,7 +551,7 @@ class TestRSACertificateRequest(object):
             x509.Extension(
                 x509.OID_BASIC_CONSTRAINTS,
                 True,
-                x509.BasicConstraints(True, 1),
+                x509.BasicConstraints(ca=True, path_length=1),
             ),
         ]
 
@@ -712,7 +712,7 @@ class TestCertificateSigningRequestBuilder(object):
                 x509.NameAttribute(x509.OID_COMMON_NAME, 'cryptography.io'),
             ])
         ).add_extension(
-            x509.BasicConstraints(False, None), critical=True,
+            x509.BasicConstraints(ca=False, path_length=None), critical=True,
         ).sign(
             backend, private_key, hashes.SHA1()
         )


### PR DESCRIPTION
- Use keyword arguments for x509.BasicConstraints in several places
- Use SHA256 instead of SHA1 in documented examples
- Give function variables meaningful names in _encode_asn1_str
- Accept a x509.BasicConstraints object in _encode_basic_constraints
- Properly garbage-collect some things
- Raise a NotImplementedError instead of a ValueError

/cc @reaperhulk @alex